### PR TITLE
fix: show full keywords in popup tags

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -107,8 +107,8 @@ label {
   padding: 4px 8px;
   border-radius: var(--radius-md);
   gap: 6px;
-  max-width: 180px;
-  white-space: nowrap;
+  max-width: 100%;
+  white-space: normal;
   transition: background-color var(--transition);
 }
 
@@ -117,9 +117,8 @@ label {
 }
 
 .tag-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .tag-remove {


### PR DESCRIPTION
Close #7

- ポップアップタグUIで、キーワードが途中で省略されずにすべて表示されるようにする。
- テキストの折り返しを許可し、タグ内の長い単語を分割できるようにする。

